### PR TITLE
Allow mulitple instances of "${TabSize}" and "${UseTab}" in formatter settings.

### DIFF
--- a/client/src/spFormat.ts
+++ b/client/src/spFormat.ts
@@ -39,8 +39,8 @@ export class SMDocumentFormattingEditProvider
 
     // Apply user settings
     default_style = default_style
-      .replace(/\${TabSize}/, tabSize)
-      .replace(/\${UseTab}/, UseTab);
+      .replace(/\${TabSize}/g, tabSize)
+      .replace(/\${UseTab}/g, UseTab);
     const start = new Position(0, 0);
     const end = new Position(
       document.lineCount - 1,


### PR DESCRIPTION
Is is, having options such as the following simply don't work. This fixes that.

```json
"sourcepawn.formatterSettings": [
    ...
    "ContinuationIndentWidth: '${TabSize}'",
    "IndentWidth: '${TabSize}'",
    ...
],
```