### PR TITLE
change spcomp to spcomp64

### DIFF
--- a/src/Commands/installSM.ts
+++ b/src/Commands/installSM.ts
@@ -36,9 +36,9 @@ export async function run(args: any) {
   let smDir = join(outputDir, "addons/sourcemod/scripting/include");
   let spComp: string;
   if (Platform === "win32") {
-    spComp = join(outputDir, "addons/sourcemod/scripting/spcomp.exe");
+    spComp = join(outputDir, "addons/sourcemod/scripting/spcomp64.exe");
   } else {
-    spComp = join(outputDir, "addons/sourcemod/scripting/spcomp");
+    spComp = join(outputDir, "addons/sourcemod/scripting/spcomp64");
   }
   if (spCompPath != "" || smHome != "") {
     window


### PR DESCRIPTION
Compiling using spcomp64 works for some reason, no idea why and still no idea what's wrong with the other this happened both on linux, windows and wsl and another friend of mine who just recently downloaded from the same link doesn't have any issues either so... Just in case others have problems :D Though I also don't know the difference between the two so this might break things I'm not aware of.