### PR TITLE
CI, Up SM compiler's version to 1.11 and add support for external includes

### DIFF
--- a/src/Commands/createGitHubActions.ts
+++ b/src/Commands/createGitHubActions.ts
@@ -74,5 +74,24 @@ export function run(rootpath?: string) {
     console.error(err);
     return 4;
   }
+
+  // Check if dependencies.sh already exists
+  masterFilePath = join(rootpath, ".github/workflows/dependencies.sh");
+  if (existsSync(masterFilePath)) {
+    const err: string = "dependencies.sh already exists, aborting.";
+    window.showErrorMessage(err);
+    console.error(err);
+    return 2;
+  }
+  tasksTemplatesPath = join(myExtDir, "templates/dependencies.sh");
+  result = readFileSync(tasksTemplatesPath, "utf-8");
+  
+  try {
+    writeFileSync(masterFilePath, result, "utf8");
+  } catch (err) {
+    console.error(err);
+    return 4;
+  }
+
   return 0;
 }

--- a/templates/dependencies.sh
+++ b/templates/dependencies.sh
@@ -1,0 +1,16 @@
+# If you want to download one specific include file, use wget and utilize the Raw link of the file 
+# ( click the file and there will be a Raw button at the top right of the code ).
+#
+# E.g.
+# wget "https://raw.githubusercontent.com/alliedmodders/sourcemod/master/plugins/include/sdkhooks.inc"
+#
+# If the include file is supposed to be in a subdirectory ( e.g. include/test/more.inc ),
+# remember to use mkdir to create the folder and then cd to change to that directory.
+#
+# E.g.
+# mkdir test
+# cd test
+# wget ...
+#
+#
+# As of now, if you want to download an entire directory you'll have to manually download each include file.

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -15,6 +15,15 @@ jobs:
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV
+
+      - name: Download plugin dependencies
+        run: |
+          mkdir scripting/include
+          cd scripting/include
+          bash ../../.github/workflows/dependencies.sh
+        working-directory: ./
+
+
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
         id: setup_sp
         uses: rumblefrog/setup-sp@master

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -19,7 +19,7 @@ jobs:
         id: setup_sp
         uses: rumblefrog/setup-sp@master
         with:
-          version: "1.10.x"
+          version: "1.11.x"
           version-file: ./scripting/${plugin_name}.sp
 
       - name: Compile plugins

--- a/templates/test_template.yml
+++ b/templates/test_template.yml
@@ -19,7 +19,7 @@ jobs:
         id: setup_sp
         uses: rumblefrog/setup-sp@master
         with:
-          version: "1.10.x"
+          version: "1.11.x"
           version-file: ./scripting/${plugin_name}.sp
 
       - name: Compile plugins

--- a/templates/test_template.yml
+++ b/templates/test_template.yml
@@ -15,6 +15,14 @@ jobs:
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV
+
+      - name: Download plugin dependencies
+        run: |
+          mkdir scripting/include
+          cd scripting/include
+          bash ../../.github/workflows/dependencies.sh
+        working-directory: ./
+
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
         id: setup_sp
         uses: rumblefrog/setup-sp@master


### PR DESCRIPTION
This PR implements the thing suggested in #268.

My Shell skills are rusty so it can probably be written better.

I have no experience with Typescript and I don't know how to get around the extension's source code, so I most likely haven't properly added dependencies.sh to the logic to create it once you create a "plugin folder".