### PR TITLE
Update the plugin workflow templates

### DIFF
--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Zip output
         run: |
-          cd plugins
-          zip -qq -r ${plugin_name}-${{ steps.setup_sp.outputs.plugin-version }}.zip ${plugin_name}.smx
+          zip -qq -y -r ${{ github.event.repository.name }}-${{ steps.setup_sp.outputs.plugin-version }}.zip configs plugins scripting extensions gamedata translations data
         working-directory: ${{ env.SCRIPTS_PATH }}
 
       - name: Create Release
@@ -53,7 +52,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ steps.setup_sp.outputs.plugin-version }}
-          artifacts: "./plugins/${plugin_name}-${{ steps.setup_sp.outputs.plugin-version }}.zip"
+          artifacts: "${{ github.event.repository.name }}-${{ steps.setup_sp.outputs.plugin-version }}.zip"
           body: ${{ steps.changelog.outputs.changes }}
           draft: false
           allowUpdates: true

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -1,8 +1,8 @@
 name: Compile and release
 
 on:
-  push:
-    branches: main
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
     permissions:
       contents: write
-    if: "!contains(github.event.head_commit.message, '[ci]')"
 
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: v${{ steps.setup_sp.outputs.plugin-version }}
+          tag: ${{ github.ref_name }}
           artifacts: "${{ github.event.repository.name }}-${{ steps.setup_sp.outputs.plugin-version }}.zip"
           body: ${{ steps.changelog.outputs.changes }}
           draft: false

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
     permissions:
       contents: write
+    if: "!contains(github.event.head_commit.message, '[ci]')"
 
     steps:
       - uses: actions/checkout@v3

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -15,11 +15,12 @@ jobs:
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV
+
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
         id: setup_sp
         uses: rumblefrog/setup-sp@master
         with:
-          version: "1.10.x"
+          version: "1.11.x"
           version-file: ./scripting/${plugin_name}.sp
 
       - name: Compile plugins

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -25,15 +25,13 @@ jobs:
 
       - name: Compile plugins
         run: |
-          mkdir plugins
-          cd scripting
-          spcomp -E -w234 -O2 -v2 -i"include" -o"../plugins/${plugin_name}.smx" ${plugin_name}.sp
+          mkdir ../plugins
+          spcomp -w234 -O2 -v2 -i"include" -o"../plugins/${plugin_name}.smx" ${plugin_name}.sp
           echo "===OUT FILES==="
-          cd ../plugins
-          ls
+          ls ../plugins
           echo "===VERSION==="
           echo ${{ steps.setup_sp.outputs.plugin-version }}
-        working-directory: ${{ env.SCRIPTS_PATH }}
+        working-directory: ${{ env.SCRIPTS_PATH }}/scripting
 
       - name: Changelog
         id: changelog

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Changelog
         id: changelog
-        uses: mindsers/changelog-reader-action@v2.0.0
+        uses: mindsers/changelog-reader-action@v2
 
       - name: Install zip
         uses: montudor/action-zip@v1

--- a/templates/main_template.yml
+++ b/templates/main_template.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/templates/test_template.yml
+++ b/templates/test_template.yml
@@ -15,11 +15,12 @@ jobs:
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV
+        
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
         id: setup_sp
         uses: rumblefrog/setup-sp@master
         with:
-          version: "1.10.x"
+          version: "1.11.x"
           version-file: ./scripting/${plugin_name}.sp
 
       - name: Compile plugins

--- a/templates/test_template.yml
+++ b/templates/test_template.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV
-        
+
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
         id: setup_sp
         uses: rumblefrog/setup-sp@master
@@ -25,12 +25,10 @@ jobs:
 
       - name: Compile plugins
         run: |
-          mkdir plugins
-          cd scripting
-          spcomp -E -w234 -O2 -v2 -i"include" -o"../plugins/${plugin_name}.smx" ${plugin_name}.sp
+          mkdir ../plugins
+          spcomp -w234 -O2 -v2 -i"include" -o"../plugins/${plugin_name}.smx" ${plugin_name}.sp
           echo "===OUT FILES==="
-          cd ../plugins
-          ls
+          ls ../plugins
           echo "===VERSION==="
           echo ${{ steps.setup_sp.outputs.plugin-version }}
-        working-directory: ${{ env.SCRIPTS_PATH }}
+        working-directory: ${{ env.SCRIPTS_PATH }}/scripting

--- a/templates/test_template.yml
+++ b/templates/test_template.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set environment variables
         run: echo SCRIPTS_PATH=$(pwd) >> $GITHUB_ENV


### PR DESCRIPTION
The extension's workflow templates are a great way to quickly have a proper way to build and release plugins on github.
However, they're out-of-date ( they can't create releases anymore ) and lack some nice-to-have functionalities.