### PR TITLE
Add support for custom server RCON commands

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -65,7 +65,7 @@
 - Call hierarchy
 - Code outline.
 - Upload to an FTP/SFTP server on successful compile.
-- Automatically run `sm plugins refresh` on a successful upload.
+- Automatically run custom commands on the server after compilation.
 - Hover for details.
 - Icons for `.smx`, `.sp` and `.inc` files
 - Automatically scan include files for natives, defines, methodmaps and more.

--- a/editors/code/esbuild.mjs
+++ b/editors/code/esbuild.mjs
@@ -68,8 +68,8 @@ let ctx = await esbuild.build({
   external: ["vscode"],
   format: "cjs",
   platform: "node",
-  loader: { ".node": "copy" },
-  plugins: [wasmPlugin, nativeNodeModulesPlugin],
+  loader: { ".node": "file" },
+  plugins: [wasmPlugin],
 });
 
 if (watch) {

--- a/editors/code/package_template.json
+++ b/editors/code/package_template.json
@@ -243,15 +243,23 @@
           "default": true,
           "description": "Whether to show the 'Compile Code' icon in editor title menu."
         },
-        "sourcepawn.refreshServerPlugins": {
+        "sourcepawn.runServerCommands": {
           "type": "string",
           "enum": [
             "disabled",
             "afterCompile",
             "afterUpload"
           ],
-          "description": "Should the plugins list on the server be refreshed with `sm plugins refresh` after a successful action in VSCode.",
+          "description": "Should the specified commands be executed on the server after a successful action in VSCode (default: sm_plugins_refresh).",
           "scope": "resource"
+        },
+        "sourcepawn.serverCommands": {
+          "type": "array",
+          "default": [
+            "sm_plugins_refresh"
+          ],
+          "scope": "resource",
+          "description": "A list of commands that will be sent to the server after a successful action in VSCode."
         },
         "sourcepawn.uploadAfterSuccessfulCompile": {
           "type": "boolean",

--- a/editors/code/package_template.json
+++ b/editors/code/package_template.json
@@ -44,7 +44,7 @@
     "onCommand:sourcepawn-vscode.createProject",
     "onCommand:sourcepawn-vscode.compileSM",
     "onCommand:sourcepawn-vscode.uploadToServer",
-    "onCommand:sourcepawn-vscode.refreshPlugins",
+    "onCommand:sourcepawn-vscode.runServerCommands",
     "onCommand:sourcepawn-vscode.insertParameters",
     "onCommand:sourcepawn-vscode.createChangelog",
     "onCommand:sourcepawn-vscode.changeSMApi",
@@ -88,8 +88,8 @@
         "category": "SM"
       },
       {
-        "command": "sourcepawn-vscode.refreshPlugins",
-        "title": "Refresh Server Plugins",
+        "command": "sourcepawn-vscode.runServerCommands",
+        "title": "Run Server Commands",
         "category": "SM"
       },
       {
@@ -250,13 +250,13 @@
             "afterCompile",
             "afterUpload"
           ],
-          "description": "Should the specified commands be executed on the server after a successful action in VSCode (default: sm_plugins_refresh).",
+          "description": "Should the specified commands be executed on the server after a successful action in VSCode (default: sm plugins refresh).",
           "scope": "resource"
         },
         "sourcepawn.serverCommands": {
           "type": "array",
           "default": [
-            "sm_plugins_refresh"
+            "sm plugins refresh"
           ],
           "scope": "resource",
           "description": "A list of commands that will be sent to the server after a successful action in VSCode."
@@ -353,7 +353,7 @@
             "timeout": 1000,
             "password": ""
           },
-          "description": "Options for the Source server to refresh the plugins on.",
+          "description": "Source server details to execute the commands on.",
           "scope": "resource"
         },
         "sourcepawn.formatterSettings": {

--- a/editors/code/src/Commands/compileSM.ts
+++ b/editors/code/src/Commands/compileSM.ts
@@ -10,7 +10,7 @@ import { existsSync, mkdirSync } from "fs";
 import { execFile } from "child_process";
 
 import { run as uploadToServerCommand } from "./uploadToServer";
-import { run as refreshPluginsCommand } from "./refreshPlugins";
+import { run as refreshPluginsCommand } from "./runServerCommands";
 import { getCtxFromUri } from "../spIndex";
 import { ProjectMainPathParams, projectMainPath } from "../lsp_ext";
 

--- a/editors/code/src/Commands/compileSM.ts
+++ b/editors/code/src/Commands/compileSM.ts
@@ -10,7 +10,7 @@ import { existsSync, mkdirSync } from "fs";
 import { execFile } from "child_process";
 
 import { run as uploadToServerCommand } from "./uploadToServer";
-import { run as refreshPluginsCommand } from "./runServerCommands";
+import { run as runServerCommands } from "./runServerCommands";
 import { getCtxFromUri } from "../spIndex";
 import { ProjectMainPathParams, projectMainPath } from "../lsp_ext";
 
@@ -183,10 +183,10 @@ export async function run(args: URI): Promise<void> {
       }
       if (
         Workspace.getConfiguration("sourcepawn", workspaceFolder).get<string>(
-          "refreshServerPlugins"
+          "runServerCommands"
         ) === "afterCompile"
       ) {
-        refreshPluginsCommand(undefined);
+        runServerCommands(undefined);
       }
     });
   } catch (error) {

--- a/editors/code/src/Commands/registerCommands.ts
+++ b/editors/code/src/Commands/registerCommands.ts
@@ -6,7 +6,7 @@ import { run as CreateMasterCommand } from "./createGitHubActions";
 import { run as CreateProjectCommand } from "./createProject";
 import { run as CompileSMCommand } from "./compileSM";
 import { run as UploadToServerCommand } from "./uploadToServer";
-import { run as RefreshPluginsCommand } from "./refreshPlugins";
+import { run as RunServerCommandsCommand } from "./runServerCommands";
 import { run as InsertParametersCommand } from "./insertParameters";
 import { run as installSMCommand } from "./installSM";
 import { run as createChangelogCommand } from "./createCHANGELOG";
@@ -71,11 +71,11 @@ export function registerSMCommands(context: vscode.ExtensionContext): void {
   );
   context.subscriptions.push(uploadToServer);
 
-  const refreshPlugins = vscode.commands.registerCommand(
-    "sourcepawn-vscode.refreshPlugins",
-    RefreshPluginsCommand.bind(undefined)
+  const runServerCommands = vscode.commands.registerCommand(
+    "sourcepawn-vscode.runServerCommands",
+    RunServerCommandsCommand.bind(undefined)
   );
-  context.subscriptions.push(refreshPlugins);
+  context.subscriptions.push(runServerCommands);
 
   const insertParameters = vscode.commands.registerCommand(
     "sourcepawn-vscode.insertParameters",
@@ -171,7 +171,7 @@ export function createServerCommands(): Record<string, CommandFactory> {
           health: "stopped",
         });
       },
-      disabled: (_) => async () => {},
+      disabled: (_) => async () => { },
     },
     openLogs: {
       enabled: (ctx) => async () => {
@@ -179,7 +179,7 @@ export function createServerCommands(): Record<string, CommandFactory> {
           ctx.client.outputChannel.show();
         }
       },
-      disabled: (_) => async () => {},
+      disabled: (_) => async () => { },
     },
     preprocessedDocument: {
       enabled: preprocessedDocumentCommand,

--- a/editors/code/src/Commands/runServerCommands.ts
+++ b/editors/code/src/Commands/runServerCommands.ts
@@ -65,8 +65,8 @@ export async function run(args: any) {
   try {
     await server.authenticate(serverOptions["password"]);
     serverCommands.forEach(async (command) => {
-      const refresh = await server.execute(command);
-      console.log(refresh);
+      const runCommands = await server.execute(command);
+      console.log(runCommands);
     });
     return 0;
   } catch (e) {

--- a/editors/code/src/Commands/runServerCommands.ts
+++ b/editors/code/src/Commands/runServerCommands.ts
@@ -17,8 +17,28 @@ export async function run(args: any) {
     "sourcepawn",
     workspaceFolder
   ).get("SourceServerOptions");
+  const serverCommands: string[] | undefined = Workspace.getConfiguration(
+    "sourcepawn",
+    workspaceFolder
+  ).get("serverCommands");
   if (serverOptions === undefined) {
     return 0;
+  }
+  if (serverCommands.length == 0) {
+    window
+      .showErrorMessage(
+        "No commands have been specified to run.",
+        "Open Settings"
+      )
+      .then((choice) => {
+        if (choice === "Open Settings") {
+          commands.executeCommand(
+            "workbench.action.openSettings",
+            "@ext:sarrus.sourcepawn-vscode"
+          );
+        }
+      });
+    return 1;
   }
   if (serverOptions["host"] == "" || serverOptions["password"] == "") {
     window
@@ -44,8 +64,10 @@ export async function run(args: any) {
   });
   try {
     await server.authenticate(serverOptions["password"]);
-    const refresh = await server.execute("sm plugins refresh");
-    console.log(refresh);
+    serverCommands.forEach(async (command) => {
+      const refresh = await server.execute(command);
+      console.log(refresh);
+    });
     return 0;
   } catch (e) {
     console.error(e);

--- a/editors/code/src/Commands/uploadToServer.ts
+++ b/editors/code/src/Commands/uploadToServer.ts
@@ -1,7 +1,7 @@
 ﻿import * as vscode from "vscode";
 import { join } from "path";
 
-import { run as refreshPluginsCommand } from "./refreshPlugins";
+import { run as runServerCommands } from "./runServerCommands";
 import { getCtxFromUri } from "../spIndex";
 import { ProjectMainPathParams, projectMainPath } from "../lsp_ext";
 import { URI } from "vscode-uri";
@@ -84,9 +84,9 @@ export async function run(args: any) {
       if (
         vscode.workspace
           .getConfiguration("sourcepawn", workspaceFolder)
-          .get<string>("refreshServerPlugins") === "afterUpload"
+          .get<string>("runServerCommands") === "afterUpload"
       ) {
-        refreshPluginsCommand(undefined);
+        runServerCommands(undefined);
       }
     })
     .catch((err) => console.error(err));


### PR DESCRIPTION
In this PR some changes have been proposed so users, via a new field in the extension settings, can specify custom commands for them to be executed in the server after a successful compilation or upload. This is exactly what's been happening already, but now without the fixed `sm plugins refresh`.