### PR TITLE
Reorder -i flags in spcomp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stdx",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -24,3 +24,6 @@ rand = "0.8.5"
 # local deps
 paths.workspace = true
 stdx.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/flycheck/src/spcomp.rs
+++ b/crates/flycheck/src/spcomp.rs
@@ -92,11 +92,6 @@ pub fn build_args(
     linter_arguments: &[String],
 ) -> Vec<String> {
     let mut args = vec![root_path.to_string()];
-    args.extend(
-        includes_directories
-            .iter()
-            .map(|includes_directory| format!("-i{}", includes_directory)),
-    );
     if let Some(parent_path) = root_path.parent() {
         args.push(format!("-i{}", parent_path));
         let include_path = parent_path.join("include");
@@ -104,6 +99,11 @@ pub fn build_args(
             args.push(format!("-i{}", include_path));
         }
     }
+    args.extend(
+        includes_directories
+            .iter()
+            .map(|includes_directory| format!("-i{}", includes_directory)),
+    );
 
     args.push(format!("-o{}", out_path));
     args.push("--syntax-only".to_string());

--- a/crates/flycheck/src/spcomp.rs
+++ b/crates/flycheck/src/spcomp.rs
@@ -112,3 +112,232 @@ pub fn build_args(
 
     args
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn abs(path: PathBuf) -> AbsPathBuf {
+        AbsPathBuf::assert(path)
+    }
+
+    /// Sets up a `<tmp>/project/plugin.sp` root path inside a fresh temp directory.
+    /// Returns the temp dir (kept alive for the duration of the test), the root path
+    /// and the project directory (i.e. the root path's parent).
+    fn setup_root() -> (tempfile::TempDir, AbsPathBuf, PathBuf) {
+        let tmp = tempdir().expect("failed to create temp dir");
+        let project_dir = tmp.path().join("project");
+        let root_path = abs(project_dir.join("plugin.sp"));
+        (tmp, root_path, project_dir)
+    }
+
+    #[test]
+    fn adds_project_directory_as_include_when_no_local_include_folder_exists() {
+        let (_tmp, root_path, project_dir) = setup_root();
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+
+        let args = build_args(&root_path, &out_path, &[], &[]);
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn adds_local_include_folder_when_it_exists_on_disk() {
+        let (_tmp, root_path, project_dir) = setup_root();
+        let include_dir = project_dir.join("include");
+        fs::create_dir_all(&include_dir).expect("failed to create include dir");
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+
+        let args = build_args(&root_path, &out_path, &[], &[]);
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-i{}", include_dir.display()),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_add_local_include_folder_when_it_does_not_exist_on_disk() {
+        let (_tmp, root_path, project_dir) = setup_root();
+        // Note: `<project_dir>/include` is intentionally not created on disk.
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+
+        let args = build_args(&root_path, &out_path, &[], &[]);
+
+        let include_dir_arg = format!("-i{}", project_dir.join("include").display());
+        assert!(
+            !args.contains(&include_dir_arg),
+            "should not add a nonexistent include folder, got: {args:?}"
+        );
+    }
+
+    /// Regression test for the fix reordering `-i` flags: project-local include
+    /// directories (the root's parent and its `include` subfolder, if any) must be
+    /// searched *before* user-configured include directories, so that local project
+    /// files take precedence over files of the same name found in a user's globally
+    /// configured include directories.
+    #[test]
+    fn user_configured_includes_are_appended_after_project_includes() {
+        let (tmp, root_path, project_dir) = setup_root();
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+        let user_include = abs(tmp.path().join("shared_includes"));
+
+        let args = build_args(
+            &root_path,
+            &out_path,
+            std::slice::from_ref(&user_include),
+            &[],
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-i{user_include}"),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn user_configured_includes_are_appended_after_local_include_folder() {
+        let (tmp, root_path, project_dir) = setup_root();
+        let include_dir = project_dir.join("include");
+        fs::create_dir_all(&include_dir).expect("failed to create include dir");
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+        let user_include = abs(tmp.path().join("shared_includes"));
+
+        let args = build_args(
+            &root_path,
+            &out_path,
+            std::slice::from_ref(&user_include),
+            &[],
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-i{}", include_dir.display()),
+                format!("-i{user_include}"),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_relative_order_of_multiple_user_configured_includes() {
+        let (tmp, root_path, project_dir) = setup_root();
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+        let user_include_a = abs(tmp.path().join("includes_a"));
+        let user_include_b = abs(tmp.path().join("includes_b"));
+        let user_include_c = abs(tmp.path().join("includes_c"));
+
+        let args = build_args(
+            &root_path,
+            &out_path,
+            &[
+                user_include_a.clone(),
+                user_include_b.clone(),
+                user_include_c.clone(),
+            ],
+            &[],
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-i{user_include_a}"),
+                format!("-i{user_include_b}"),
+                format!("-i{user_include_c}"),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    /// Edge case: a root path that has no parent directory (e.g. sitting at the
+    /// filesystem root) must not panic, must not contribute a project include, and
+    /// must still append user-configured include directories.
+    #[test]
+    fn handles_root_path_without_a_parent_directory() {
+        let tmp = tempdir().expect("failed to create temp dir");
+        let fs_root = tmp.path().ancestors().last().unwrap().to_path_buf();
+        let root_path = abs(fs_root);
+        assert!(
+            root_path.parent().is_none(),
+            "test setup requires a root path without a parent"
+        );
+        let out_path = abs(tmp.path().join("plugin.smx"));
+        let user_include = abs(tmp.path().join("shared_includes"));
+
+        let args = build_args(
+            &root_path,
+            &out_path,
+            std::slice::from_ref(&user_include),
+            &[],
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{user_include}"),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn appends_linter_arguments_after_include_and_output_flags() {
+        let (tmp, root_path, project_dir) = setup_root();
+        let out_path = root_path.parent().unwrap().join("plugin.smx");
+        let user_include = abs(tmp.path().join("shared_includes"));
+        let linter_arguments = vec!["-w3".to_string(), "--verbose=2".to_string()];
+
+        let args = build_args(
+            &root_path,
+            &out_path,
+            std::slice::from_ref(&user_include),
+            &linter_arguments,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                root_path.to_string(),
+                format!("-i{}", project_dir.display()),
+                format!("-i{user_include}"),
+                format!("-o{out_path}"),
+                "--syntax-only".to_string(),
+                "-w3".to_string(),
+                "--verbose=2".to_string(),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `spcomp`'s `-i` search order matters: the first directory containing a match wins. `build_args` was listing user-configured `includeDirectories` *before* the compiled file's own directory and its local `include/` subfolder, so a stale or unrelated file in a globally-configured include path could shadow the correct, up-to-date file living right next to the script being compiled.
- This caused flycheck diagnostics to disagree with hover/go-to-definition, which resolve `#include`s via `resolve_include_node` in `hir-def` and already check the file's own directory and local `include/` folder *before* falling back to configured roots. Users would see a symbol correctly resolved on hover, yet flagged as an "undefined symbol" `spcomp` error.
- Reordered the `-i` flags in `build_args` so the project-local directory and its `include/` subfolder are searched first, matching the resolution order already used elsewhere in the extension.

## Test plan

- [x] Reproduced the bug against a real project with a shadowed/stale `mge.inc` in a globally-configured include directory: `spcomp` failed with `error 017: undefined symbol` for a symbol that only existed in the newer, project-local `mge.inc`.
- [x] Re-ran with the reordered flags and confirmed the compile succeeds with zero errors.
- [x] `cargo build -p flycheck` passes with no warnings/lints.