### PR TITLE
Fix encoding crashes

### DIFF
--- a/crates/hir-def/src/ast_id_map.rs
+++ b/crates/hir-def/src/ast_id_map.rs
@@ -123,6 +123,9 @@ impl AstIdMap {
         let mut arena = Arena::default();
         let mut map = FxHashMap::default();
         bdfs(root_node, &mut |node: tree_sitter::Node<'_>| {
+            if node.is_error() || node.is_missing() {
+                return false;
+            }
             match TSKind::from(node) {
                 TSKind::source_file => (),
                 TSKind::global_variable_declaration
@@ -229,5 +232,31 @@ impl Index<AstId> for AstIdMap {
     type Output = NodePtr;
     fn index(&self, index: AstId) -> &Self::Output {
         &self.arena[index.raw]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(text: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_sourcepawn::language())
+            .expect("Failed to set language");
+        parser.parse(text, None).expect("Failed to parse")
+    }
+
+    /// Regression test for a crash where a transient parser `ERROR` node
+    /// (kind id `u16::MAX`) was fed into `TSKind::from`, which used to
+    /// blindly `transmute` the id and panic on any value not covered by
+    /// the grammar's node kinds.
+    #[test]
+    fn from_source_does_not_panic_on_error_node() {
+        let text = "#include <tf2items";
+        let tree = parse(text);
+        assert!(tree.root_node().has_error());
+
+        let _ = AstIdMap::from_source(&tree.root_node());
     }
 }

--- a/crates/sourcepawn-studio/src/client.rs
+++ b/crates/sourcepawn-studio/src/client.rs
@@ -77,8 +77,9 @@ impl LspClient {
             .pending
             .remove(&response.id)
             .expect("response with unknown request id received");
-        if response.result.is_none() {
-            // Ignore null responses, as they will be sent on a disconnected channel.
+        if response.result.is_none() && response.error.is_none() {
+            // Ignore null successful responses, as they will be sent on a disconnected channel.
+            // Error responses must still be forwarded, since they also have `result: None`.
             return Ok(());
         }
         log::debug!("Sending received response {:?}", response);

--- a/crates/sourcepawn-studio/src/global_state.rs
+++ b/crates/sourcepawn-studio/src/global_state.rs
@@ -320,12 +320,16 @@ impl GlobalState {
                 let text = if file.exists() {
                     let bytes = vfs.file_contents(file.file_id).to_vec();
 
-                    String::from_utf8(bytes).ok().map(|text| {
-                        // FIXME: Consider doing normalization in the `vfs` instead? That allows
-                        // getting rid of some locking
-                        let (text, line_endings) = LineEndings::normalize(text);
-                        (Arc::from(text), line_endings)
-                    })
+                    // Files are decoded lossily rather than rejected outright on invalid UTF-8.
+                    // The file is still visible to `#include` resolution regardless (its bytes
+                    // exist in the `Vfs`), so silently skipping the `line_endings_map` entry here
+                    // (as a strict `String::from_utf8` would force us to) would desync the two
+                    // and panic later on, e.g. when resolving a goto-definition into this file.
+                    let text = String::from_utf8_lossy(&bytes).into_owned();
+                    // FIXME: Consider doing normalization in the `vfs` instead? That allows
+                    // getting rid of some locking
+                    let (text, line_endings) = LineEndings::normalize(text);
+                    Some((Arc::from(text), line_endings))
                 } else {
                     None
                 };

--- a/crates/sourcepawn-studio/tests/text_document/goto_definition/crash_repro.rs
+++ b/crates/sourcepawn-studio/tests/text_document/goto_definition/crash_repro.rs
@@ -28,8 +28,11 @@ fn goto_definition_on_include_with_invalid_utf8_content() {
     // picked up by the background workspace file loader, not by
     // `textDocument/didOpen`.
     let foo_inc_path = test_bed.directory().join("foo.inc");
-    std::fs::write(&foo_inc_path, [b'i', b'n', b't', b' ', b'f', b'o', b'o', b';', 0xFF])
-        .unwrap();
+    std::fs::write(
+        &foo_inc_path,
+        [b'i', b'n', b't', b' ', b'f', b'o', b'o', b';', 0xFF],
+    )
+    .unwrap();
 
     test_bed
         .initialize(

--- a/crates/sourcepawn-studio/tests/text_document/goto_definition/crash_repro.rs
+++ b/crates/sourcepawn-studio/tests/text_document/goto_definition/crash_repro.rs
@@ -1,0 +1,137 @@
+use sourcepawn_studio::fixture::TestBed;
+use std::{thread, time::Duration};
+
+/// Regression test for the "no entry found for key" panic reported against
+/// `GlobalStateSnapshot::file_line_index`.
+///
+/// A file that is discovered by the workspace file loader (i.e. not opened
+/// through `textDocument/didOpen`) is registered in the analysis' source
+/// roots so `#include` resolution can find it and goto-definition can target
+/// it. If that file's bytes are not valid UTF-8, its content used to be
+/// dropped entirely, which meant it never got an entry inserted in the line
+/// endings map. Any subsequent goto-definition targeting that file then
+/// panicked when computing the line index for the response.
+#[test]
+fn goto_definition_on_include_with_invalid_utf8_content() {
+    let fixture = r#"
+%! main.sp
+#include "foo.inc"
+           |
+           ^
+"#;
+
+    let test_bed = TestBed::new(fixture, false).unwrap();
+
+    // `foo.inc` is intentionally *not* part of the fixture text (Rust string
+    // literals can't contain invalid UTF-8), so it is written directly to
+    // disk with a byte sequence that is not valid UTF-8. It will only be
+    // picked up by the background workspace file loader, not by
+    // `textDocument/didOpen`.
+    let foo_inc_path = test_bed.directory().join("foo.inc");
+    std::fs::write(&foo_inc_path, [b'i', b'n', b't', b' ', b'f', b'o', b'o', b';', 0xFF])
+        .unwrap();
+
+    test_bed
+        .initialize(
+            serde_json::from_value(serde_json::json!({
+                "textDocument": {
+                    "definition": {
+                        "linkSupport": true
+                    }
+                },
+                "workspace": {
+                    "configuration": true,
+                    "workspace_folders": true
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+    // Give the background file loader time to discover and load `foo.inc`.
+    thread::sleep(Duration::from_millis(500));
+
+    let text_document_position = test_bed.cursor().unwrap();
+    let params = lsp_types::request::GotoTypeDefinitionParams {
+        text_document_position_params: text_document_position,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+
+    let response = test_bed
+        .client()
+        .send_request::<lsp_types::request::GotoDefinition>(params)
+        .expect("goto-definition should not panic on a non-UTF-8 include file");
+
+    assert!(
+        response.is_some(),
+        "expected a location to be resolved for `foo`, got: {response:?}"
+    );
+}
+
+/// Real-world variant of the above, using the actual `tf2items.inc` shipped
+/// in the official `tf2items-1.6.4-hg279` releases (both the Windows and
+/// Linux zips, dated 2015-12-17, MD5 `4d4ec8cfa71df4af94c0de470cacff51`).
+/// Its ASCII-art footer comment uses Windows-1252 bytes for a handful of
+/// special characters, making the whole file invalid UTF-8. This is the
+/// exact file and `#include <...>` (chevron) syntax originally reported to
+/// crash the extension.
+#[test]
+#[allow(invalid_from_utf8)]
+fn goto_definition_on_official_tf2items_inc_chevron_include() {
+    let real_bytes = include_bytes!("fixtures/tf2items_invalid_utf8.inc");
+    assert!(
+        std::str::from_utf8(real_bytes).is_err(),
+        "sanity check: the fixture file is expected to be invalid UTF-8"
+    );
+
+    let fixture = r#"
+%! main.sp
+#include <tf2items>
+           |
+           ^
+"#;
+
+    let test_bed = TestBed::new(fixture, false).unwrap();
+
+    let include_dir = test_bed.directory().join("include");
+    std::fs::create_dir_all(&include_dir).unwrap();
+    std::fs::write(include_dir.join("tf2items.inc"), real_bytes).unwrap();
+
+    test_bed
+        .initialize(
+            serde_json::from_value(serde_json::json!({
+                "textDocument": {
+                    "definition": {
+                        "linkSupport": true
+                    }
+                },
+                "workspace": {
+                    "configuration": true,
+                    "workspace_folders": true
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+    // Give the background file loader time to discover and load `tf2items.inc`.
+    thread::sleep(Duration::from_millis(500));
+
+    let text_document_position = test_bed.cursor().unwrap();
+    let params = lsp_types::request::GotoTypeDefinitionParams {
+        text_document_position_params: text_document_position,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+
+    let response = test_bed
+        .client()
+        .send_request::<lsp_types::request::GotoDefinition>(params)
+        .expect("goto-definition should not panic on the official tf2items.inc");
+
+    assert!(
+        response.is_some(),
+        "expected a location to be resolved for `tf2items`, got: {response:?}"
+    );
+}

--- a/crates/sourcepawn-studio/tests/text_document/goto_definition/fixtures/tf2items_invalid_utf8.inc
+++ b/crates/sourcepawn-studio/tests/text_document/goto_definition/fixtures/tf2items_invalid_utf8.inc
@@ -1,0 +1,255 @@
+#if defined _tf2items_included
+#endinput
+#endif
+#define _tf2items_included
+
+#include <tf2>
+
+// ====[ CONSTANTS ]===========================================================
+#define OVERRIDE_CLASSNAME		(1 << 0)	// Item will override the entity's classname.
+#define OVERRIDE_ITEM_DEF			(1 << 1)	// Item will override the item's definition index.
+#define OVERRIDE_ITEM_LEVEL		(1 << 2)	// Item will override the entity's level.
+#define OVERRIDE_ITEM_QUALITY		(1 << 3)	// Item will override the entity's quality.
+#define OVERRIDE_ATTRIBUTES		(1 << 4)	// Item will override the attributes for the item with the given ones.
+#define OVERRIDE_ALL				(0b11111)	// Magically enables all the other flags.
+
+#define PRESERVE_ATTRIBUTES		(1 << 5)
+#define FORCE_GENERATION		(1 << 6)
+
+// ====[ NATIVES ]=============================================================
+
+/**
+ * WARNING: This is for ADVANCED users only!
+ * You probably want to be using the forward instead of this.
+ *
+ * This native will perform a GiveNamedItem call for the specified client in
+ * order to generate an object based on the specifications of the TF2Items
+ * object passed to it.
+ * 
+ * Since the item generation requires all the information that can be passed by
+ * the extensions natives, the flags will be ignored and all the given
+ * information will be used.
+ * 
+ * Remember that if your values aren't correct, this call may end up in a crash,
+ * so please make sure you fill out everything: Classname, item definition index,
+ * quality, level and attributes.
+ * 
+ * @param iClient	Client that the item will be generated for.
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			Entity index of the newly created item.
+ */
+native TF2Items_GiveNamedItem(iClient, Handle:hItem);
+
+/**
+ * Creates a TF2Items object, wich can be used to override the parameters of an
+ * item before it's given to the client, or to create a new completely new one
+ * with GiveNamedItem. Remember to free the object with CloseHandle()
+ *
+ * @param iFlags		Flags used to specify what to override.
+ * @return				Handle to the TFItems object.
+ */
+native Handle:TF2Items_CreateItem(iFlags);
+
+/**
+ * Sets the flags to determine what the item will override on the GiveNamedItem.
+ * Use the OVERRIDE_ defines to set what you will be changing.
+ *
+ * @param hItem			Handle to the TF2Items object that we'll be operating with.
+ * @param iFlags		Flags used to specify what to override.
+ * @noreturn
+ */
+native TF2Items_SetFlags(Handle:hItem, iFlags);
+
+/**
+ * Sets the new entity classname used for the item's entity.
+ *
+ * @param hItem				Handle to the TF2Items object that we'll be operating with.
+ * @param strClassName		New classname to use for the entity.
+ * @noreturn
+ */
+native TF2Items_SetClassname(Handle:hItemOverride, String:strClassName[]);
+
+/**
+ * Sets the item's Definition Index, wich tells the game what item it is. Each
+ * weapon/hat/item has an unique definition index. Find these out in the
+ * game_items.txt
+ * 
+ * @param hItem				Handle to the TF2Items object that we'll be operating with.
+ * @param iItemDefIndex		New definition index.
+ * @noreturn
+ */
+native TF2Items_SetItemIndex(Handle:hItem, iItemDefIndex);
+
+/**
+ * Sets the item's quality value, wich determines what color will be used for
+ * the item name. Valid values are from 0 to 9.
+ * 
+ * @param hItem					Handle to the TF2Items object that we'll be operating with.
+ * @param iEntityQuality		New item quality.
+ * @noreturn
+ */
+native TF2Items_SetQuality(Handle:hItem, iEntityQuality);
+
+/**
+ * Sets the item's level value. This value can range from 0 to 127.
+ * 
+ * @param hItem				Handle to the TF2Items object that we'll be operating with.
+ * @param iEntityLevel		New item level.
+ * @noreturn
+ */
+native TF2Items_SetLevel(Handle:hItem, iEntityLevel);
+
+/**
+ * Sets the number of attributes that will be used on the item. The maximum
+ * number of attributes that can be allocated ranges from 0 to 15.
+ * 
+ * @param hItem					Handle to the TF2Items object that we'll be operating with.
+ * @param iNumAttributes		Number of attributes.
+ * @noreturn
+ */
+native TF2Items_SetNumAttributes(Handle:hItem, iNumAttributes);
+
+/**
+ * Setups the given attribute index to use the attribute and values specified
+ * with iAttribDefIndex and flValue. Remember the iSlotIndex ranges from 0 to 15.
+ * 
+ * @param hItem					Handle to the TF2Items object that we'll be operating with.
+ * @param iSlotIndex			The attribute slot index, ranges from 0 to 15.
+ * @param iAttribDefIndex		The attribute definition index, as it appears on game_items.txt.
+ * @param flValue				The value assigned to the attribute (how much health, damage, etc.).
+ * @noreturn
+ */
+native TF2Items_SetAttribute(Handle:hItem, iSlotIndex, iAttribDefIndex, Float:flValue);
+
+/**
+ * Retrieves the flags used to determine what the item will override on the
+ * GiveNamedItem call.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			Returns the flags used by the item.
+ */
+native TF2Items_GetFlags(Handle:hItem);
+
+/**
+ * Gets the entity classname we'll use for the item.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			New classname to use for the entity.
+ */
+native TF2Items_GetClassname(Handle:hItem, String:strDest[], iDestSize);
+
+/**
+ * Gets the new item definition index we'll use to override.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			New definition index.
+ */
+native TF2Items_GetItemIndex(Handle:hItem); 
+
+/**
+ * Gets the item's quality value, wich determines what color will be used for
+ * the item name. Valid values are from 0 to 9. But if set to 0 and attributes
+ * are also changed, this value will be overridden to 9
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			New entity quality.
+ */
+native TF2Items_GetQuality(Handle:hItem); 
+
+/**
+ * Gets the item's level value. This value can range from 0 to 127.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			New entity level.
+ */
+native TF2Items_GetLevel(Handle:hItem);
+
+/**
+ * Gets the number of attributes that will be used on the item. The maximum
+ * number of attributes that can be allocated ranges from 0 to 15.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			Number of attributes.
+ */
+native TF2Items_GetNumAttributes(Handle:hItem);
+
+/**
+ * Retrieves the attribute definition index used at the specified index on the
+ * item object. Remember the iSlotIndex ranges from 0 to 15.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			The attribute definition index to use.
+ */
+native TF2Items_GetAttributeId(Handle:hItem, iSlotIndex);
+
+/**
+ * Retrieves the value used for the attribute at the specified index on the item
+ * object. Remember the iSlotIndex ranges from 0 to 15.
+ *
+ * @param hItem		Handle to the TF2Items object that we'll be operating with.
+ * @return			The attribute value to use.
+ */
+native Float:TF2Items_GetAttributeValue(Handle:hItem, iSlotIndex); 
+
+// ====[ FORWARDS ]============================================================
+/**
+ * Called when an item is about to be given to a client.
+ * Return Plugin_Changed to override the item to use the configuration of the hItem object.
+ * Return Plugin_Continue to keep them intact.
+ * Return Plugin_Handled to stop the item being given to the player.
+ * Make sure the client gets atleast one weapon.
+ *
+ * @param client				Client Index.
+ * @param classname				The classname of the entity that will be generated.
+ * @param iItemDefinitionIndex	Item definition index.
+ * @param hItem					Handle to a TF2Item object wich describes what values will be overriden.
+ */
+forward Action:TF2Items_OnGiveNamedItem(client, String:classname[], iItemDefinitionIndex, &Handle:hItem);
+
+forward TF2Items_OnGiveNamedItem_Post(client, String:classname[], itemDefinitionIndex, itemLevel, itemQuality, entityIndex);
+
+/**
+ * Do not edit below this line!
+ */
+public Extension:__ext_tf2items = 
+{
+	name = "TF2Items",
+	file = "tf2items.ext.2.ep2v",
+	autoload = 0,
+	#if defined REQUIRE_EXTENSIONS
+		required = 1,
+	#else
+		required = 0,
+	#endif
+}
+	
+/**
+* I'll just leave this here...
+* 
+* _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< _(º< 
+* \__) \__) \__) \__) \__) \__) \__) \__) \__) 
+*                     .  .
+*                    // //  __
+*         __  ______||_//_.´.´
+*       _/__`´            ¯ `
+*      /  / _          _     \
+*     /  /( · )      ( · )    |
+*    /  |   ¯     __   ¯    _/\/|
+*   |    \  ___.-´  `-.___  \   /
+*    \    \(     ` ´      `)|   \
+*     \     )              //     \
+*      \/  /              | |     |
+*     /   /               | |     |
+*    ·   |                |  \___/
+*    |    \_            _/      \  ____
+*    ·      `----------´         |´    \
+*     \                         /    _·´
+*      \                       /  _-´ 
+*        `-._               _·´-´
+*        _.-´`---________--´ \ 
+*       ´-.-. _--·   / .   ._ \
+*            ´       `´ `·´  `´
+* >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ >º)_ 
+* (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ (__/ 
+* 
+*/

--- a/crates/sourcepawn-studio/tests/text_document/goto_definition/mod.rs
+++ b/crates/sourcepawn-studio/tests/text_document/goto_definition/mod.rs
@@ -2,6 +2,7 @@ use insta::assert_json_snapshot;
 use sourcepawn_studio::fixture::goto_definition;
 
 mod arrays;
+mod crash_repro;
 mod enum_structs;
 mod enums;
 mod function_declarations;

--- a/crates/syntax/src/generated.rs
+++ b/crates/syntax/src/generated.rs
@@ -275,9 +275,13 @@ pub enum TSKind {
     anon_call_arguments_repeat1_ = 270,
     anon_array_literal_repeat1_ = 271,
     anon_string_literal_repeat1_ = 272,
+    anon_ERROR = 65535,
 }
 impl From<tree_sitter::Node<'_>> for TSKind {
     fn from(v: tree_sitter::Node<'_>) -> Self {
+        if v.is_error() {
+            return TSKind::anon_ERROR;
+        }
         unsafe { ::std::mem::transmute(v.kind_id()) }
     }
 }

--- a/crates/syntax/src/tests/sourcegen.rs
+++ b/crates/syntax/src/tests/sourcegen.rs
@@ -39,16 +39,24 @@ fn generate_node_kinds() {
         let kind_id: TokenStream = format!("{}", kind_id).parse().unwrap();
         quote! { #name = #kind_id }
     });
+    // tree-sitter reserves `u16::MAX` as the kind id of the built-in `ERROR` node.
+    // It is not part of the grammar's node kinds (i.e. outside of `0..node_kind_count`),
+    // so it needs its own variant to be transmuted safely from a `kind_id`.
+    let error_entry = quote! { anon_ERROR = 65535 };
     let stream = quote! {
         #![allow(bad_style, missing_docs, unreachable_pub, unused)]
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
         #[repr(u16)]
         pub enum TSKind {
-            #(#entries),*
+            #(#entries),*,
+            #error_entry,
         }
 
         impl From<tree_sitter::Node<'_>> for TSKind {
             fn from(v: tree_sitter::Node<'_>) -> Self {
+                if v.is_error() {
+                    return TSKind::anon_ERROR;
+                }
                 unsafe { ::std::mem::transmute(v.kind_id()) }
             }
         }


### PR DESCRIPTION
## Summary

Fixes two extension crashes reported when working with `tf2items.inc` and related include files.

### 1. Panic on tree-sitter `ERROR` nodes (`0xffff`)

While typing an incomplete `#include` directive, tree-sitter can emit transient `ERROR` nodes with kind id `u16::MAX`. `TSKind::from` used to blindly `transmute` that id, which panicked because the enum had no matching variant.

- Add an `anon_ERROR` variant to `TSKind` and handle `node.is_error()` in the generated `From` impl
- Skip `is_error()` / `is_missing()` nodes in `AstIdMap::from_source`
- Add a unit regression test in `ast_id_map`

### 2. Panic on goto-definition into non-UTF-8 include files (`no entry found for key`)

Files discovered by the background workspace loader (but not opened via `textDocument/didOpen`) could be resolvable via `#include` while missing from the `line_endings_map`. This happened when `process_changes` used strict `String::from_utf8` and silently dropped file content on decode failure.

Reproduced with the official `tf2items.inc` from `tf2items-1.6.4-hg279` (both Windows and Linux zips). Its ASCII-art footer uses Windows-1252 bytes, making the file invalid UTF-8. Ctrl+clicking `#include <tf2items>` then panicked in `GlobalStateSnapshot::file_line_index`.

- Decode file bytes with `String::from_utf8_lossy` so `line_endings_map` always stays in sync with `#include` resolution
- Fix `LspClient::recv_response` so server error responses (`result: None`, `error: Some(...)`) are forwarded to tests instead of being dropped
- Add integration regression tests, including one using the real official `tf2items.inc` fixture

## Test plan

- [x] `cargo test --workspace`
- [x] Reproduced the `no entry found for key` panic locally against `test-tf2items` with the official `tf2items-1.6.4-hg279` `tf2items.inc`
- [x] Verified goto-definition on `#include <tf2items>` no longer crashes after the fix (F5 debug build)
- [x] Smoke test typing an incomplete `#include` directive while editing